### PR TITLE
feat: add cast function

### DIFF
--- a/daqm/data/data_frame.py
+++ b/daqm/data/data_frame.py
@@ -245,36 +245,31 @@ class DataFrameQuery:
       elif col.func == "cast":
         # TODO: numeric or decimal: 사용자 지정 정밀도 유형 추가
         # TODO: interval 추가(입력되는 unit에 따라 to_timedelta 함수의 unit 파라미터 변경)
-        if col.options["target_type"] == "bigint":  # integer(8)
-          res_col = df[col.columns[0].name].astype("float").astype("Int64")
-        elif col.options["target_type"] == "boolean":
-          res_col = df[col.columns[0].name].astype("boolean")
-        elif col.options["target_type"] == "char":
-          res_col = df[col.columns[0].name].astype(str)
-        elif col.options["target_type"] == "date":
-          res_col = df[col.columns[0].name].astype("datetime64[ns]")
+        convert_map_dict = {
+            "bigint": ["float", "Int64"],
+            "int": ["float", "Int32"],
+            "smallint": ["float", "Int16"],
+            "boolean": ["boolean"],
+            "double precision": ["float64"],
+            "float": ["float64"],
+            "real": ["float32"],
+            "date": ["datetime64[ns]"],
+            "datetime": ["datetime64[ns]"],
+            "time": ["datetime64[ns]"],
+            "char": [str],
+            "varchar": [str],
+            "text": [str]
+        }
+        target_type_list = convert_map_dict.get(col.options["target_type"])
+
+        res_col = df[col.columns[0].name]
+        for target_type in target_type_list:
+          res_col = res_col.astype(target_type)
+
+        if col.options["target_type"] == "date":
           res_col = res_col.dt.date
-        elif col.options["target_type"] == "datetime":
-          res_col = df[col.columns[0].name].astype("datetime64[ns]")
-        elif col.options["target_type"] == "double precision":  # float(64)
-          res_col = df[col.columns[0].name].astype("float64")
-        elif col.options["target_type"] == "float":  # float(64)
-          res_col = df[col.columns[0].name].astype("float64")
-        elif col.options["target_type"] == "int":  # integer(4)
-          res_col = df[col.columns[0].name].astype("float").astype("Int32")
-        elif col.options["target_type"] == "real":  # float(32)
-          res_col = df[col.columns[0].name].astype("float32")
-        elif col.options["target_type"] == "smallint":  # integer(2)
-          res_col = df[col.columns[0].name].astype("float").astype("Int16")
-        elif col.options["target_type"] == "varchar":
-          res_col = df[col.columns[0].name].astype(str)
-        elif col.options["target_type"] == "text":
-          res_col = df[col.columns[0].name].astype(str)
         elif col.options["target_type"] == "time":
-          res_col = df[col.columns[0].name].astype("datetime64[ns]")
           res_col = res_col.dt.time
-        else:
-          raise ValueError(f"target_type '{col.options['target_type']}' is not available in Cast function.")
       else:
         raise NotImplementedError(f"Function {col.func} not implemented for DataFrame.")
       df.loc[:, col.name] = res_col

--- a/daqm/data/data_frame.py
+++ b/daqm/data/data_frame.py
@@ -242,6 +242,39 @@ class DataFrameQuery:
       elif col.func == "or":
         condition_df_list = [df[each_col.name] for each_col in col.columns]
         res_col = functools.reduce(np.logical_or, condition_df_list)
+      elif col.func == "cast":
+        # TODO: numeric or decimal: 사용자 지정 정밀도 유형 추가
+        # TODO: interval 추가(입력되는 unit에 따라 to_timedelta 함수의 unit 파라미터 변경)
+        if col.options["target_type"] == "bigint":  # integer(8)
+          res_col = df[col.columns[0].name].astype("float").astype("Int64")
+        elif col.options["target_type"] == "boolean":
+          res_col = df[col.columns[0].name].astype("boolean")
+        elif col.options["target_type"] == "char":
+          res_col = df[col.columns[0].name].astype(str)
+        elif col.options["target_type"] == "date":
+          res_col = df[col.columns[0].name].astype("datetime64[ns]")
+          res_col = res_col.dt.date
+        elif col.options["target_type"] == "datetime":
+          res_col = df[col.columns[0].name].astype("datetime64[ns]")
+        elif col.options["target_type"] == "double precision":  # float(64)
+          res_col = df[col.columns[0].name].astype("float64")
+        elif col.options["target_type"] == "float":  # float(64)
+          res_col = df[col.columns[0].name].astype("float64")
+        elif col.options["target_type"] == "int":  # integer(4)
+          res_col = df[col.columns[0].name].astype("float").astype("Int32")
+        elif col.options["target_type"] == "real":  # float(32)
+          res_col = df[col.columns[0].name].astype("float32")
+        elif col.options["target_type"] == "smallint":  # integer(2)
+          res_col = df[col.columns[0].name].astype("float").astype("Int16")
+        elif col.options["target_type"] == "varchar":
+          res_col = df[col.columns[0].name].astype(str)
+        elif col.options["target_type"] == "text":
+          res_col = df[col.columns[0].name].astype(str)
+        elif col.options["target_type"] == "time":
+          res_col = df[col.columns[0].name].astype("datetime64[ns]")
+          res_col = res_col.dt.time
+        else:
+          raise ValueError(f"target_type '{col.options['target_type']}' is not available in Cast function.")
       else:
         raise NotImplementedError(f"Function {col.func} not implemented for DataFrame.")
       df.loc[:, col.name] = res_col

--- a/daqm/data/db_table.py
+++ b/daqm/data/db_table.py
@@ -168,6 +168,12 @@ class DBTableQuery:
         query = " and ".join(self.query_map[each_col] for each_col in col.columns)
       elif col.func == "or":
         query = " or ".join(self.query_map[each_col] for each_col in col.columns)
+      elif col.func == "cast":
+        if col.options["target_type"] == "datetime":
+          cast_type = "timestamp"
+        else:
+          cast_type = col.options["target_type"]
+        query = f"cast({self.query_map[col.columns[0]]} AS {cast_type})"
       else:
         raise NotImplementedError(f"Function {col.func} not implemented for DataFrame.")
       self.query_map[col] = query

--- a/daqm/data/query.py
+++ b/daqm/data/query.py
@@ -466,6 +466,22 @@ class QueryFunction:
     in_cols = [Column.cast(col) for col in in_cols]
     return FunctionalColumn("in", target_col, *in_cols)
 
+  # Cast
+  @staticmethod
+  def cast(col: Column, target_type: str) -> FunctionalColumn:
+    """
+    Column 객체를 지정한 데이터 유형으로 변환합니다.
+
+    :param col: 변환할 대상 Column 객체
+    :param target_type: 변환할 데이터 유형
+    """
+    if target_type not in [
+        "bigint", "boolean", "date", "datetime", "double precision", "float",
+        "int", "smallint", "real", "char", "varchar", "text", "time"
+    ]:
+      raise ValueError(f"target_type '{target_type}' is not available in Cast function.")
+    return FunctionalColumn("cast", col, target_type=target_type)
+
   # !!! IMPORTANT NOTE      QueryFunction Marker
   # If add function here, need to implement it's functionality.
   # Search for "QueryFunction Marker" comments

--- a/tests/data/test_query.py
+++ b/tests/data/test_query.py
@@ -552,10 +552,12 @@ class BaseTestQuery:
     query = self.data.query.select(
         func.cast("1", "int").label("cast_int"),
         func.cast(1, "boolean").label("cast_boolean"),
+        func.cast(1234567890, "bigint").label("cast_bigint"),
+        func.cast(1.234567890, "double precision").label("cast_dbp"),
         func.cast("2021-12-27", "date").label("cast_date"),
         func.cast("2021-12-27 12:00:00", "datetime").label("cast_datetime"),
         func.cast("2021-12-27 12:00:00", "time").label("cast_time"),
-        func.cast("127.1234567", "float").label("cast_float"),
+        func.cast("127.1234567", "real").label("cast_real"),
         func.cast(10, "varchar").label("cast_varchar"),
     )
 
@@ -563,10 +565,12 @@ class BaseTestQuery:
 
     assert [types == "int" for types in result_df["cast_int"].map(type)]
     assert [types == "bool" for types in result_df["cast_boolean"].map(type)]
+    assert [types == "int" for types in result_df["cast_bigint"].map(type)]
+    assert [types == "float" for types in result_df["cast_dbp"].map(type)]
     assert [types == "datetime.date" for types in result_df["cast_date"].map(type)]
     assert [types == "datetime.datetime" for types in result_df["cast_datetime"].map(type)]
     assert [types == "datetime.time" for types in result_df["cast_time"].map(type)]
-    assert [types == "float" for types in result_df["cast_float"].map(type)]
+    assert [types == "float" for types in result_df["cast_real"].map(type)]
     assert [types == "str" for types in result_df["cast_varchar"].map(type)]
 
   def test_apply_function(self):

--- a/tests/data/test_query.py
+++ b/tests/data/test_query.py
@@ -548,6 +548,27 @@ class BaseTestQuery:
     result = self.query_to_df(query)
     assert [row == 123 for row in result["intA"]]
 
+  def test_cast(self):
+    query = self.data.query.select(
+        func.cast("1", "int").label("cast_int"),
+        func.cast(1, "boolean").label("cast_boolean"),
+        func.cast("2021-12-27", "date").label("cast_date"),
+        func.cast("2021-12-27 12:00:00", "datetime").label("cast_datetime"),
+        func.cast("2021-12-27 12:00:00", "time").label("cast_time"),
+        func.cast("127.1234567", "float").label("cast_float"),
+        func.cast(10, "varchar").label("cast_varchar"),
+    )
+
+    result_df = self.query_to_df(query)
+
+    assert [types == "int" for types in result_df["cast_int"].map(type)]
+    assert [types == "bool" for types in result_df["cast_boolean"].map(type)]
+    assert [types == "datetime.date" for types in result_df["cast_date"].map(type)]
+    assert [types == "datetime.datetime" for types in result_df["cast_datetime"].map(type)]
+    assert [types == "datetime.time" for types in result_df["cast_time"].map(type)]
+    assert [types == "float" for types in result_df["cast_float"].map(type)]
+    assert [types == "str" for types in result_df["cast_varchar"].map(type)]
+
   def test_apply_function(self):
     def apply_func(row):
       new_row = []


### PR DESCRIPTION
* closes #18 

### cast 함수 구현 논의가 필요한 점
* python 데이터 유형과 SQL 데이터 유형이 다름
  - 예: python의 text 유형은 str, SQL의 text 유형은 char, varchar, text 일 때, cast 함수에 지원 가능한 유형을 SQL 쪽으로 맞추었음
* 정밀소수점 미지원:
  - Numeric, decimal 구현 방법 고민 (precision, scale 파라미터가 필요. python에서도 지원가능한지 확인이 필요)
* Interval 미지원:
  - unit에 따라, pd.to_timedelta(unit)이 다르게 지정되어야 함.
  - unit을 컬럼에서 `series.str.split(" ", expand=True)[1]`으로 추출해서 변수로 만들었을때, 각 row 마다 pd.to_timedelta(unit)에 넣어줄 수 있을지..
  - sqlalchemy 에서는 `func.cast(concat(8, ' HOURS'), INTERVAL)` 처럼 사용 가능