### PR TITLE
feat(function): modify time_diif and extract functions

### DIFF
--- a/daqm/data/data_frame.py
+++ b/daqm/data/data_frame.py
@@ -200,7 +200,7 @@ class DataFrameQuery:
         if col.options["method"] == "relativedelta":
           res_col = df.apply(lambda x: relativedelta(x[col.columns[0].name], x[col.columns[1].name]), axis=1)
         else:
-          res_col = df[col.columns[0].name] - df[col.columns[1].name] # mothod == "timedelta"
+          res_col = df[col.columns[0].name] - df[col.columns[1].name] # method == "timedelta"
       elif col.func == "extract":
         if np.issubdtype(df[col.columns[0].name].dtype, relativedelta):
           res_col = df.apply(lambda x: eval(f"x[col.columns[0].name].{col.options['field_value']}s"), axis=1)
@@ -209,7 +209,7 @@ class DataFrameQuery:
         else:
           if np.issubdtype(df[col.columns[0].name].dtype, np.timedelta64):
             raise ValueError(
-                "You might consider <method = 'relativedelta'> when using 'extract' with 'time_diff' together.")
+                "You must consider <method = 'relativedelta'> when using 'extract' with 'time_diff' together.")
           else:
             raise ValueError(
                 "Expected column type to be one of ('date', 'datetime', 'relativedelta'), you might need to add explicit type casts.")

--- a/daqm/data/data_frame.py
+++ b/daqm/data/data_frame.py
@@ -209,7 +209,7 @@ class DataFrameQuery:
         else:
           if np.issubdtype(df[col.columns[0].name].dtype, np.timedelta64):
             raise ValueError(
-                "You might consider method = 'relativedelta' in 'time_diff' function when using 'extract' with 'time_diff' together."
+                "You might consider <method = 'relativedelta'> when using 'extract' with 'time_diff' together."
             )
           else:
             raise ValueError(

--- a/daqm/data/data_frame.py
+++ b/daqm/data/data_frame.py
@@ -197,15 +197,24 @@ class DataFrameQuery:
         else:
           res_col = pd.to_timedelta(df[value_col.name], unit="days")
       elif col.func == "time_diff":
-        res_col = df.apply(lambda x: relativedelta(x[col.columns[0].name], x[col.columns[1].name]), axis=1)
+        if col.options["method"] == "relativedelta":
+          res_col = df.apply(lambda x: relativedelta(x[col.columns[0].name], x[col.columns[1].name]), axis=1)
+        else:
+          res_col = df[col.columns[0].name] - df[col.columns[1].name] # mothod == "timedelta"
       elif col.func == "extract":
         if np.issubdtype(df[col.columns[0].name].dtype, relativedelta):
           res_col = df.apply(lambda x: eval(f"x[col.columns[0].name].{col.options['field_value']}s"), axis=1)
         elif np.issubdtype(df[col.columns[0].name].dtype, np.datetime64):
           res_col = eval(f"df[col.columns[0].name].dt.{col.options['field_value']}")
         else:
-          raise ValueError(
-              "Expected column type to be one of ('date', 'datetime', 'relativedelta'), you might need to add explicit type casts.")
+          if np.issubdtype(df[col.columns[0].name].dtype, np.timedelta64):
+            raise ValueError(
+                "You might consider method = 'relativedelta' in 'time_diff' function when using 'extract' with 'time_diff' together."
+            )
+          else:
+            raise ValueError(
+                "Expected column type to be one of ('date', 'datetime', 'relativedelta'), you might need to add explicit type casts."
+          )
       elif col.func == "case":
         res_col = pd.Series(None, index=df.index)
         for idx in range(0, len(col.columns), 2):

--- a/daqm/data/data_frame.py
+++ b/daqm/data/data_frame.py
@@ -209,12 +209,10 @@ class DataFrameQuery:
         else:
           if np.issubdtype(df[col.columns[0].name].dtype, np.timedelta64):
             raise ValueError(
-                "You might consider <method = 'relativedelta'> when using 'extract' with 'time_diff' together."
-            )
+                "You might consider <method = 'relativedelta'> when using 'extract' with 'time_diff' together.")
           else:
             raise ValueError(
-                "Expected column type to be one of ('date', 'datetime', 'relativedelta'), you might need to add explicit type casts."
-          )
+                "Expected column type to be one of ('date', 'datetime', 'relativedelta'), you might need to add explicit type casts.")
       elif col.func == "case":
         res_col = pd.Series(None, index=df.index)
         for idx in range(0, len(col.columns), 2):

--- a/daqm/data/query.py
+++ b/daqm/data/query.py
@@ -485,16 +485,22 @@ class QueryFunction:
     return FunctionalColumn("date_delta", col)
 
   @staticmethod
-  def time_diff(end_datetime_col: Column, start_datetime_col: Column) -> FunctionalColumn:
+  def time_diff(end_datetime_col: Column, start_datetime_col: Column, method: str = "timedelta") -> FunctionalColumn:
     """
-    날짜(date, datetime) 간의 차이를 나타냅니다.
+    날짜(date, datetime)간의 차이를 나타냅니다.
     db: return timedelta type
-    data_frame: return relativedelta type
+    data_frame: return timedelta type (method: "timedelta") or relativedelta type (method: "relativedelta")
 
     :param end_date_col: 종료일
     :param start_date_col: 시작일
+    :param method: 날짜간의 차이를 구하는 방법 (dafault: "timedelta"), data_frame에서만 활용되는 인자
+    "timedelta"일 시, days hours:minutes:seconds 정보 반환,
+    "relativedelta"일 시, years months days hours:minutes:seconds 정보 반환
     """
-    return FunctionalColumn("time_diff", end_datetime_col, start_datetime_col)
+    method_tuple = ("timedelta", "relativedelta")
+    if method not in method_tuple:
+      raise ValueError(f"Expected field value: {method!r} to be one of {method_tuple}")
+    return FunctionalColumn("time_diff", end_datetime_col, start_datetime_col, method=method)
 
   @staticmethod
   def extract(col: Column, field_value: str) -> FunctionalColumn:

--- a/tests/data/test_query.py
+++ b/tests/data/test_query.py
@@ -15,6 +15,7 @@ from daqm.data.columns import (
     OperatedColumn,
     and_, or_, between
 )
+from daqm.data.data_frame import DataFrameData
 from daqm.data.db_table import DBTableData
 from daqm.data.query import Query, func
 from tests.utils import TEST_ORDER_DATA
@@ -456,7 +457,8 @@ class BaseTestQuery:
         func.date(self.data.c.dateYear, self.data.c.dateMonth, self.data.c.dateDay),
         self.data.c.dateA + func.date_delta(10),
         self.data.c.dateA + func.date_delta(self.data.c.intA),
-        func.time_diff(self.data.c.dateB, self.data.c.dateA)
+        func.time_diff(self.data.c.dateB, self.data.c.dateA, method="timedelta"),
+        func.time_diff(self.data.c.datetimeB, self.data.c.datetimeA, method="relativedelta")
     )
 
     result_df = self.query_to_df(query)
@@ -464,7 +466,11 @@ class BaseTestQuery:
     for source, result in zip(self.data.to_df().values, result_df.values):
       date_a = source[self.col_to_idx["dateA"]]
       date_b = source[self.col_to_idx["dateB"]]
+
       int_a = source[self.col_to_idx["intA"]]
+
+      datetime_a = source[self.col_to_idx["datetimeA"]]
+      datetime_b = source[self.col_to_idx["datetimeB"]]
 
       date_year = source[self.col_to_idx["dateYear"]]
       date_month = source[self.col_to_idx["dateMonth"]]
@@ -478,10 +484,10 @@ class BaseTestQuery:
       assert result[3] == date_a + timedelta(days=10)
       assert result[4] == date_a + timedelta(days=int_a)
 
-      if isinstance(self.data, DBTableData):
-        assert result[5] == (date_b - date_a)
-      else:
-        assert result[5] == relativedelta(date_b, date_a)
+      assert result[5] == (date_b - date_a)
+      
+      if isinstance(self.data, DataFrameData):
+        assert result[6] == relativedelta(datetime_b, datetime_a)
 
     query = self.data.query.select(
         func.extract(self.data.c.datetimeA, "year").label("year"),
@@ -500,27 +506,27 @@ class BaseTestQuery:
 
     query = self.data.query.select(
         func.extract(
-            func.time_diff(self.data.c.datetimeB, self.data.c.datetimeA),
+            func.time_diff(self.data.c.datetimeB, self.data.c.datetimeA, method="relativedelta"),
             "year"
         ).label("year"),
         func.extract(
-            func.time_diff(self.data.c.datetimeB, self.data.c.datetimeA),
+            func.time_diff(self.data.c.datetimeB, self.data.c.datetimeA, method="relativedelta"),
             "month"
         ).label("month"),
         func.extract(
-            func.time_diff(self.data.c.datetimeB, self.data.c.datetimeA),
+            func.time_diff(self.data.c.datetimeB, self.data.c.datetimeA, method="relativedelta"),
             "day"
         ).label("day"),
         func.extract(
-            func.time_diff(self.data.c.datetimeB, self.data.c.datetimeA),
+            func.time_diff(self.data.c.datetimeB, self.data.c.datetimeA, method="relativedelta"),
             "hour"
         ).label("hour"),
         func.extract(
-            func.time_diff(self.data.c.datetimeB, self.data.c.datetimeA),
+            func.time_diff(self.data.c.datetimeB, self.data.c.datetimeA, method="relativedelta"),
             "minute"
         ).label("minute"),
         func.extract(
-            func.time_diff(self.data.c.datetimeB, self.data.c.datetimeA),
+            func.time_diff(self.data.c.datetimeB, self.data.c.datetimeA, method="relativedelta"),
             "second"
         ).label("second")
     )


### PR DESCRIPTION
### 이슈
- close #34 

### 내용
- time_diff 내 method값에 `relativedelta`, `timedelta`추가 (default: `timedelta`)
- DataFrame:
  - `method = relativedelta`시, (relative) 년 월 일 시 분 초 return
  - `method = timedelta`시, (relative) 일 시 분 초 return
- DB:
  - method와 상관없이 (absolute) 일 시 분 초 return